### PR TITLE
Fix: dont error fully out when single api groupVersion not found

### DIFF
--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -23,8 +23,9 @@ const kubeResourceMetaCache = {};
 
 module.exports = class KubeClass {
 
-  constructor(kubeApiConfig) {
+  constructor(kubeApiConfig, logger) {
     this._kubeApiConfig = kubeApiConfig;
+    this._log = logger || require('./bunyan-api').createLogger('kubeClass');
     this._baseOptions = merge({
       headers: {
         Accept: 'application/json'
@@ -69,8 +70,13 @@ module.exports = class KubeClass {
 
   async getApisAll(group) {
     let result = [];
-    await Promise.all(objectPath.get(group, 'versions', []).map(v => {
-      return this.getApisSingle(v.groupVersion, (krm) => result.push(krm));
+    await Promise.all(objectPath.get(group, 'versions', []).map(async v => {
+      try {
+        await this.getApisSingle(v.groupVersion, (krm) => result.push(krm));
+      } catch (e) {
+        this._log.warn(e);
+      }
+      return;
     }));
     return result;
   }
@@ -82,10 +88,18 @@ module.exports = class KubeClass {
     for (var i = versions.length - 1; i > -1; i--) {
       let v = versions[i];
       if (v.groupVersion !== preferredGroupVersion) {
-        await this.getApisSingle(v.groupVersion, (krm) => latest[krm.name] = krm);
+        try {
+          await this.getApisSingle(v.groupVersion, (krm) => latest[krm.name] = krm);
+        } catch (e) {
+          this._log.warn(e);
+        }
       }
     }
-    await this.getApisSingle(preferredGroupVersion, (krm) => latest[krm.name] = krm);
+    try {
+      await this.getApisSingle(preferredGroupVersion, (krm) => latest[krm.name] = krm);
+    } catch (e) {
+      this._log.warn(e);
+    }
 
     return Object.values(latest);
   }

--- a/test/kubeClass-test.js
+++ b/test/kubeClass-test.js
@@ -17,7 +17,7 @@ const assert = require('chai').assert;
 const nock = require('nock');
 const deepEqual = require('deep-equal');
 const { KubeClass } = require('../index');
-const objectPath = require('object-path');
+// const objectPath = require('object-path');
 
 describe('kubeClass', function () {
 
@@ -134,12 +134,9 @@ describe('kubeClass', function () {
         })
         .get('/apis/batch/v1')
         .reply(200, { kind: 'NotAPIResourceList' });
-      try {
-        await kc.getApis();
-        assert.fail('should not successfully return from getApis()');
-      } catch (e) {
-        assert.equal(objectPath.get(e, 'body.kind'), 'NotAPIResourceList', 'Error body shoud contain bad kind "NotAPIResourceList"');
-      }
+
+      let res = await kc.getApis();
+      assert.equal(res.length, 0, 'Error should return successfully, but without the failed resource');
     });
 
     it('#404', async () => {
@@ -161,7 +158,7 @@ describe('kubeClass', function () {
       try {
         await kc.getApis();
       } catch (e) {
-        assert.deepEqual(e, { statusCode: 404, body: { msg: 'not found' }, message: 'Error getting /apis/batch/v2alpha1'});
+        assert.deepEqual(e, { statusCode: 404, body: { msg: 'not found' }, message: 'Error getting /apis/batch/v2alpha1' });
       }
 
 


### PR DESCRIPTION
this commit slightly changes the fail behavior when a particular groupVersion isnt found or is having issue (ie. service unavailable). Before we would reject with error all the way back to the caller, now we will only warn that there was an issue. The return behavior remains the same, if we were unable to find the requested resource (or if there was an error calling the requested endpoint), the caller will get back undefined.