### PR TITLE
Fix: actually use the config path option if passed

### DIFF
--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -34,7 +34,7 @@ module.exports = function kubeApiConfig(options = {}) {
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
     return _kubeApiConfig.kubeConfig;
-  } else if (kubeconfigPath && fileExists(kubeconfigPath)) {
+  } else if (kubeconfigPath && fs.existsSync(kubeconfigPath)) {
     kc.loadFromFile(kubeconfigPath);
   } else {
     kc.loadFromCluster();
@@ -81,14 +81,4 @@ module.exports = function kubeApiConfig(options = {}) {
 
 function base64Decode(o) {
   return Buffer.from(o, 'base64').toString('utf8');
-}
-
-function fileExists(path) {
-  try {
-    fs.accessSync(path);
-    return true;
-  } catch (err) {
-    // failed to find path
-  }
-  return false;
 }

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -34,12 +34,8 @@ module.exports = function kubeApiConfig(options = {}) {
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
     return _kubeApiConfig.kubeConfig;
-  } else if (kubeconfigPath) {
-    kubeconfigPath = kubeconfigPath.split('/');
-    kubeconfigPath.pop();
-    kubeconfigPath = kubeconfigPath.join('/');
-
-    kc.loadFromDefault();
+  } else if (kubeconfigPath && fileExists(kubeconfigPath)) {
+    kc.loadFromFile(kubeconfigPath);
   } else {
     kc.loadFromCluster();
   }
@@ -85,4 +81,14 @@ module.exports = function kubeApiConfig(options = {}) {
 
 function base64Decode(o) {
   return Buffer.from(o, 'base64').toString('utf8');
+}
+
+function fileExists(path) {
+  try {
+    fs.accessSync(path);
+    return true;
+  } catch (err) {
+    // failed to find path
+  }
+  return false;
 }


### PR DESCRIPTION
Was previously relying on process.env.KUBECONFIG to be set in order to use `kc.loadFromDefault()`. But what i really want is to specically point to the admin kubeconfig and load from that file.