### PR TITLE
Fix: bug where resources with same name aren't both kept

### DIFF
--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -188,15 +188,35 @@ module.exports = class KubeClass {
   async getKubeResourcesMeta(verb) {
     var [core, apis] = await Promise.all([this.getCoreApis(), this.getApis(false)]);
 
-    var apisNameHash = {};
+    let crds = [];
+    try {
+      const crdsHash = {};
+      let response = await request.get('/apis/apiextensions.k8s.io/v1/customresourcedefinitions', this._baseOptions);
+      if (response.statusCode == 200 && objectPath.get(response, 'body.kind') === 'CustomResourceDefinitionList') {
+        objectPath.get(response, 'body.items', []).map(crd => {
+          crdsHash[`/apis/${objectPath.get(crd, 'spec.group')}`] = true;
+        });
+        crds = Object.keys(crdsHash);
+      } else {
+        throw response.body;
+      }
+    } catch (e) {
+      this._log.warn(e, 'Could not list crds, if there are duplicated plural names, the returned kubeResourceMeta list will be incomplete.');
+    }
+
+    const apisNameHash = {};
+    const crdApis = [];
     apis.map((api) => {
-      if (apisNameHash[api.name] === undefined || apisNameHash[api.name].uri().startsWith('/apis/extensions/')) {
+      const includes = (el) => api.path.startsWith(el);
+      if (crds.some(includes)) {
+        crdApis.push(api);
+      } else if (apisNameHash[api.name] === undefined || apisNameHash[api.name].uri().startsWith('/apis/extensions/')) {
         apisNameHash[api.name] = api;
       }
     });
     apis = Object.values(apisNameHash);
 
-    var result = core.concat(apis);
+    var result = core.concat(apis, crdApis);
     if (verb) {
       result = result.filter(r => r.hasVerb(verb));
     }


### PR DESCRIPTION
when multiple resources, due to the  creation of CRDs, have the same plural name, it results in an incomplete kubeResourceMeta list because of the way we stored the data. This change now will pull out crds into their own array in order to preserve all crds, but still allow for us to remove depricated "/apis/extensions" endpoints.