### PR TITLE
fix: use cloned krms for user impersonation

### DIFF
--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -35,9 +35,9 @@ module.exports = class EventHandler {
     this._logger = params.logger || require('../bunyan-api').createLogger('EventHandler');
 
     if (!(this._kubeResourceMeta &&
-        this._kubeResourceMeta.constructor &&
-        this._kubeResourceMeta.constructor.name === 'KubeResourceMeta' &&
-        this._kubeResourceMeta.hasVerb('watch'))) {
+      this._kubeResourceMeta.constructor &&
+      this._kubeResourceMeta.constructor.name === 'KubeResourceMeta' &&
+      this._kubeResourceMeta.hasVerb('watch'))) {
       throw Error('Resource does not support verb "watch"');
     }
     if (!this._kc) {
@@ -68,7 +68,7 @@ module.exports = class EventHandler {
   // Event Handler
   async eventHandler(data) {
     let params = {
-      kubeResourceMeta: this._kubeResourceMeta,
+      kubeResourceMeta: this._kubeResourceMeta.clone(),
       eventData: data,
       kubeClass: this._kc,
       logger: this._logger,

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -27,12 +27,6 @@ module.exports = class KubeResourceMeta {
     this._logger = require('./bunyan-api').createLogger('KubeResourceMeta');
   }
 
-  // need to test the issue around creating multiple rr/rrs3 and the impersonated user getting stuck between the 2,
-  // but when all rrs3 are deleted, it is able to go back to impersonating razeedeploy. (eg. the impersonated user one the first rr doesnt have
-  // the proper access, and if you remove the impersonated user, it still sticks to the deleted user. also if you create a second resource 
-  // with no user defined, it also is stuck on that first user. But if you delete both resources manually, its able to revert back to razeedeploy )
-  // also need to test impersonation when a user only has access to a couple namespaces
-
   clone() {
     return new KubeResourceMeta(this._path, this._resourceMeta, this._kubeApiConfig);
   }

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -27,6 +27,16 @@ module.exports = class KubeResourceMeta {
     this._logger = require('./bunyan-api').createLogger('KubeResourceMeta');
   }
 
+  // need to test the issue around creating multiple rr/rrs3 and the impersonated user getting stuck between the 2,
+  // but when all rrs3 are deleted, it is able to go back to impersonating razeedeploy. (eg. the impersonated user one the first rr doesnt have
+  // the proper access, and if you remove the impersonated user, it still sticks to the deleted user. also if you create a second resource 
+  // with no user defined, it also is stuck on that first user. But if you delete both resources manually, its able to revert back to razeedeploy )
+  // also need to test impersonation when a user only has access to a couple namespaces
+
+  clone() {
+    return new KubeResourceMeta(this._path, this._resourceMeta, this._kubeApiConfig);
+  }
+
   uri(options = {}) {
     let result = `${this._path}`;
     if (options.watch) {

--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -246,7 +246,7 @@ module.exports = class KubeClass {
     if (verb && krm && !krm.hasVerb(verb)) {
       krm = undefined;
     }
-    return krm.clone();
+    return krm !== undefined ? krm.clone() : krm;
   }
 
 };

--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -246,7 +246,7 @@ module.exports = class KubeClass {
     if (verb && krm && !krm.hasVerb(verb)) {
       krm = undefined;
     }
-    return krm;
+    return krm.clone();
   }
 
 };


### PR DESCRIPTION
now that we are adding extra data to KRMs like impersonated users, we need the krms to be unique per CRD event to avoid conflict bewtween different CRD instances. (ie. if there are 2 remoteresource objects, but only one of them has user impersonation defined, they will both use the one defined user. I havent tested it, but i assume if they both have users defined, there is a race condition on which user will be impersonated).