### PR TITLE
fix: Use Rotated Service Account Auth Token

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "parserOptions": {
-        "ecmaVersion": 8,
+        "ecmaVersion": 2022,
         "sourceType": "module"
     },
     "env": {
@@ -11,11 +11,11 @@
     "extends": "eslint:recommended",
     "rules": {
         "indent": [
-          "error",
-          2,
-          {
-            "SwitchCase": 1
-          }
+            "error",
+            2,
+            {
+                "SwitchCase": 1
+            }
         ],
         "linebreak-style": [
             "error",

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 const touch = require('touch');
 const watchman = require('./Watchman');
 const objectPath = require('object-path');
+
 
 module.exports = class EventHandler {
   constructor(params = {}) {

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -60,7 +60,6 @@ module.exports = class EventHandler {
     }
 
     // Gather variables and use to create watchman
-    // TODO: refetch kubeApiConfig when the this._wm.watch() is called again
     let opt = {
       logger: this._logger,
       requestOptions: { ...(params.requestOptions ?? {}), uri: this._kubeResourceMeta.uri({ watch: true }) }

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -18,7 +18,6 @@ const touch = require('touch');
 const watchman = require('./Watchman');
 const objectPath = require('object-path');
 
-
 module.exports = class EventHandler {
   constructor(params = {}) {
     this._kubeResourceMeta = params.kubeResourceMeta;

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -32,11 +32,6 @@ module.exports = class EventHandler {
         this._livenessInterval = 60000; //One minute
       }
     }
-    this._livenessEndHours = params.restartPod; // time in hours when we should stop updating the liveness file, which should tell kube to restart our pod. If 0 is defined, pod will not be told to restart. Default: 0.
-    if (!Number.isInteger(this._livenessEndHours)) {
-      const livenessEndHours = Number.parseInt(this._livenessEndHours);
-      this._livenessEndHours = (livenessEndHours >= 0) ? livenessEndHours : 0;
-    }
     this._watchTimeoutSeconds = objectPath.get(params, 'requestOptions.qs.timeoutSeconds', 300); // time in seconds when the watch should be re-initialized. default: 300s
     if (!Number.isInteger(this._watchTimeoutSeconds)) {
       const watchTimeoutSeconds = Number.parseInt(this._watchTimeoutSeconds);
@@ -69,13 +64,13 @@ module.exports = class EventHandler {
 
     if (this._livenessInterval) {
       touch.sync('/tmp/liveness');
-      let livenessStartTime = Date.now(); // time liveness was first initialized
       setInterval(() => {
         const now = Date.now();
-        const millisecondsSinceLivenessStart = now - livenessStartTime;
-        const hoursSinceLivenessStart = millisecondsSinceLivenessStart / 1000 / 60 / 60;
-        const restartThresholdHours = this._livenessEndHours; // stop touching liveness file after the specified number of hours, which should tell kube to restart the pod
-        if (this._wm.watching && (restartThresholdHours == 0 || hoursSinceLivenessStart < restartThresholdHours)) { // (watching && restartThresholdHours not defined) || (watching && hoursSinceLivenessStart < restartThresholdHours)
+        const millisecondsSinceLastStart = now - this._wm.watchStart;
+        const resetThresholdMilliseconds = (this._watchTimeoutMilliseconds + 10000); // interval time and kube timing is not exact, so adding 10 seconds to allow for variance in the watch being restarted by kube
+        this._logger.debug(`Time since last start: ${millisecondsSinceLastStart / 1000}s | WatchTimeoutSeconds: ${resetThresholdMilliseconds / 1000}s.`);
+        // if watching and time since last start is less than the desired watch restart threshold, then we are still alive.
+        if (this._wm.watching && (millisecondsSinceLastStart < resetThresholdMilliseconds)) {
           touch.sync('/tmp/liveness');
         }
       }, this._livenessInterval);

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const merge = require('deepmerge');
+
 const touch = require('touch');
 const watchman = require('./Watchman');
 const objectPath = require('object-path');
@@ -63,8 +63,7 @@ module.exports = class EventHandler {
     // TODO: refetch kubeApiConfig when the this._wm.watch() is called again
     let opt = {
       logger: this._logger,
-      requestOptions: merge(this._kubeResourceMeta.kubeApiConfig(), params.requestOptions || {}),
-      watchUri: this._kubeResourceMeta.uri({ watch: true })
+      requestOptions: { ...(params.requestOptions ?? {}), uri: this._kubeResourceMeta.uri({ watch: true }) }
     };
     this._wm = new watchman(opt, (data) => this.eventHandler(data));
     this._wm.watch();

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -60,9 +60,10 @@ module.exports = class EventHandler {
     }
 
     // Gather variables and use to create watchman
+    // TODO: refetch kubeApiConfig when the this._wm.watch() is called again
     let opt = {
       logger: this._logger,
-      requestOptions: merge(this._kubeResourceMeta.kubeApiConfig, params.requestOptions || {}),
+      requestOptions: merge(this._kubeResourceMeta.kubeApiConfig(), params.requestOptions || {}),
       watchUri: this._kubeResourceMeta.uri({ watch: true })
     };
     this._wm = new watchman(opt, (data) => this.eventHandler(data));

--- a/lib/EventHandler.js
+++ b/lib/EventHandler.js
@@ -56,7 +56,7 @@ module.exports = class EventHandler {
     // Gather variables and use to create watchman
     let opt = {
       logger: this._logger,
-      requestOptions: { ...(params.requestOptions ?? {}), uri: this._kubeResourceMeta.uri({ watch: true }) }
+      requestOptions: { ...params?.requestOptions, uri: this._kubeResourceMeta.uri({ watch: true }) }
     };
     this._wm = new watchman(opt, (data) => this.eventHandler(data));
     this._wm.watch();

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -35,14 +35,16 @@ module.exports = function kubeApiConfig(options = {}) {
   }
 
   // ===== Kubernetes-Client/Javascript  =====
-  process.env.KUBECONFIG = process.env.KUBECONFIG ?? options.kubeConfigPath;
-
+  if (typeof options.kubeConfigPath === 'string') {
+    process.env.KUBECONFIG = options.kubeConfigPath;
+  }
 
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
     _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval; // refresh in refreshInterval or 5 minutes if not defined
     return _kubeApiConfig.kubeConfig;
   } else {
+    // First tries to load from process.env.KUBECONFIG, then from $HOME/.kube/config, then finally loadFromCluster
     kc.loadFromDefault();
   }
 

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -20,44 +20,49 @@ const k8s = require('@kubernetes/client-node');
 const kc = new k8s.KubeConfig();
 
 
-var _kubeApiConfig = {};
+const _kubeApiConfig = {};
 
 module.exports = function kubeApiConfig(options = {}) {
-  var result = {};
+  const result = {};
+  const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
+  const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000;
 
-  if (_kubeApiConfig.kubeConfig && options.refreshCache !== true) {
+  if (options.refreshCache === true || Date.now() > refreshTimestamp) {
+    delete _kubeApiConfig.kubeConfig;
+  }
+  if (_kubeApiConfig.kubeConfig) {
     return _kubeApiConfig.kubeConfig;
   }
 
   // ===== Kubernetes-Client/Javascript  =====
-  let kubeconfigPath = process.env.KUBECONFIG || options.kubeConfigPath;
+  process.env.KUBECONFIG = process.env.KUBECONFIG ?? options.kubeConfigPath;
+
 
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
+    _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval; // refresh in refreshInterval or 5 minutes if not defined
     return _kubeApiConfig.kubeConfig;
-  } else if (kubeconfigPath && fs.existsSync(kubeconfigPath)) {
-    kc.loadFromFile(kubeconfigPath);
   } else {
-    kc.loadFromCluster();
+    kc.loadFromDefault();
   }
 
   const cluster = kc.getCurrentCluster();
   const user = kc.getCurrentUser();
 
   if (cluster.caFile) {
-    let path = (cluster.caFile.startsWith('/') || !kubeconfigPath) ? cluster.caFile : `${kubeconfigPath}/${cluster.caFile}`;
+    let path = (cluster.caFile.startsWith('/') || !process.env.KUBECONFIG) ? cluster.caFile : `${process.env.KUBECONFIG}/${cluster.caFile}`;
     result.ca = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (cluster.caData || user['certificate-authority-data']) {
     result.ca = base64Decode(cluster.caData || user['certificate-authority-data']);
   }
   if (user.certFile) {
-    let path = (user.certFile.startsWith('/') || !kubeconfigPath) ? user.certFile : `${kubeconfigPath}/${user.certFile}`;
+    let path = (user.certFile.startsWith('/') || !process.env.KUBECONFIG) ? user.certFile : `${process.env.KUBECONFIG}/${user.certFile}`;
     result.cert = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (user.certData || user['client-certificate-data']) {
     result.cert = base64Decode(user.certData || user['client-certificate-data']);
   }
   if (user.keyFile) {
-    let path = (user.keyFile.startsWith('/') || !kubeconfigPath) ? user.keyFile : `${kubeconfigPath}/${user.keyFile}`;
+    let path = (user.keyFile.startsWith('/') || !process.env.KUBECONFIG) ? user.keyFile : `${process.env.KUBECONFIG}/${user.keyFile}`;
     result.key = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (user.keyData || user['client-key-data']) {
     result.key = base64Decode(user.keyData || user['client-key-data']);
@@ -80,6 +85,7 @@ module.exports = function kubeApiConfig(options = {}) {
 
   objectPath.set(result, 'headers.User-Agent', `${userAgentName}/${userAgentVersion}`);
   _kubeApiConfig.kubeConfig = result;
+  _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval; // refresh in refreshInterval or 5 minutes if not defined
   return result;
 };
 

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -31,34 +31,37 @@ module.exports = function kubeApiConfig(options = {}) {
   }
 
   // ===== Kubernetes-Client/Javascript  =====
+  let kubeconfigPath = options.kubeConfigPath;
+
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
     _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval;
     return _kubeApiConfig.kubeConfig;
-  } else if (typeof options.kubeConfigPath === 'string' && fs.existsSync(options.kubeConfigPath)) {
-    kc.loadFromFile(options.kubeConfigPath);
+  } else if (typeof kubeconfigPath === 'string' && fs.existsSync(kubeconfigPath)) {
+    kc.loadFromFile(kubeconfigPath);
   } else {
     // First tries to load from process.env.KUBECONFIG, then from $HOME/.kube/config, then finally loadFromCluster
     kc.loadFromDefault();
+    kubeconfigPath = (typeof process.env.KUBECONFIG === 'string' && fs.existsSync(process.env.KUBECONFIG)) ? process.env.KUBECONFIG : undefined;
   }
 
   const cluster = kc.getCurrentCluster();
   const user = kc.getCurrentUser();
 
   if (cluster.caFile) {
-    let path = (cluster.caFile.startsWith('/') || !process.env.KUBECONFIG) ? cluster.caFile : `${process.env.KUBECONFIG}/${cluster.caFile}`;
+    let path = (cluster.caFile.startsWith('/') || !kubeconfigPath) ? cluster.caFile : `${kubeconfigPath}/${cluster.caFile}`;
     result.ca = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (cluster.caData || user['certificate-authority-data']) {
     result.ca = base64Decode(cluster.caData || user['certificate-authority-data']);
   }
   if (user.certFile) {
-    let path = (user.certFile.startsWith('/') || !process.env.KUBECONFIG) ? user.certFile : `${process.env.KUBECONFIG}/${user.certFile}`;
+    let path = (user.certFile.startsWith('/') || !kubeconfigPath) ? user.certFile : `${kubeconfigPath}/${user.certFile}`;
     result.cert = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (user.certData || user['client-certificate-data']) {
     result.cert = base64Decode(user.certData || user['client-certificate-data']);
   }
   if (user.keyFile) {
-    let path = (user.keyFile.startsWith('/') || !process.env.KUBECONFIG) ? user.keyFile : `${process.env.KUBECONFIG}/${user.keyFile}`;
+    let path = (user.keyFile.startsWith('/') || !kubeconfigPath) ? user.keyFile : `${kubeconfigPath}/${user.keyFile}`;
     result.key = fs.readFileSync(path, { encoding: 'utf8' });
   } else if (user.keyData || user['client-key-data']) {
     result.key = base64Decode(user.keyData || user['client-key-data']);

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -24,8 +24,9 @@ const _kubeApiConfig = {};
 module.exports = function kubeApiConfig(options = {}) {
   const result = {};
   const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
-  const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined
+  const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined. matches the default cycle interval.
 
+  // if kubeconfig is deinfed and refresh cache not requested and we havent hit the refreshTimestamp, then return cached kubeconfig
   if (_kubeApiConfig.kubeConfig && options.refreshCache !== true && Date.now() < refreshTimestamp) {
     return _kubeApiConfig.kubeConfig;
   }

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -27,6 +27,8 @@ module.exports = function kubeApiConfig(options = {}) {
   const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
   const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined
 
+  // if there is an error response from kube that tells us the token is stale ( i still need to figure out if there is ),
+  // we can have the caller of kubeApiConfig() retry their request with kubeApiConfig({refreshCache: true})
   if (options.refreshCache === true || Date.now() > refreshTimestamp) {
     delete _kubeApiConfig.kubeConfig;
   }

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -26,7 +26,7 @@ module.exports = function kubeApiConfig(options = {}) {
   const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
   const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined
 
-  if (_kubeApiConfig.kubeConfig && !(options.refreshCache === true || Date.now() > refreshTimestamp)) {
+  if (_kubeApiConfig.kubeConfig && options.refreshCache !== true && Date.now() < refreshTimestamp) {
     return _kubeApiConfig.kubeConfig;
   }
 

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -25,7 +25,7 @@ const _kubeApiConfig = {};
 module.exports = function kubeApiConfig(options = {}) {
   const result = {};
   const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
-  const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000;
+  const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined
 
   if (options.refreshCache === true || Date.now() > refreshTimestamp) {
     delete _kubeApiConfig.kubeConfig;
@@ -41,7 +41,7 @@ module.exports = function kubeApiConfig(options = {}) {
 
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
-    _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval; // refresh in refreshInterval or 5 minutes if not defined
+    _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval;
     return _kubeApiConfig.kubeConfig;
   } else {
     // First tries to load from process.env.KUBECONFIG, then from $HOME/.kube/config, then finally loadFromCluster

--- a/lib/KubeApiConfig.js
+++ b/lib/KubeApiConfig.js
@@ -15,7 +15,6 @@
  */
 const packagejson = require('../package.json');
 const fs = require('fs-extra');
-const objectPath = require('object-path');
 const k8s = require('@kubernetes/client-node');
 const kc = new k8s.KubeConfig();
 
@@ -27,24 +26,17 @@ module.exports = function kubeApiConfig(options = {}) {
   const refreshTimestamp = _kubeApiConfig?.refreshTimestamp ?? 0;
   const refreshInterval = parseInt(process.env.KUBECONFIG_REFRESH_INTERVAL ?? options.refreshInterval) || 300000; // refresh kubeconfig in refreshInterval or 5 minutes if not defined
 
-  // if there is an error response from kube that tells us the token is stale ( i still need to figure out if there is ),
-  // we can have the caller of kubeApiConfig() retry their request with kubeApiConfig({refreshCache: true})
-  if (options.refreshCache === true || Date.now() > refreshTimestamp) {
-    delete _kubeApiConfig.kubeConfig;
-  }
-  if (_kubeApiConfig.kubeConfig) {
+  if (_kubeApiConfig.kubeConfig && !(options.refreshCache === true || Date.now() > refreshTimestamp)) {
     return _kubeApiConfig.kubeConfig;
   }
 
   // ===== Kubernetes-Client/Javascript  =====
-  if (typeof options.kubeConfigPath === 'string') {
-    process.env.KUBECONFIG = options.kubeConfigPath;
-  }
-
   if (options.localhost) {
     _kubeApiConfig.kubeConfig = { baseUrl: `http://localhost:${options.port || 8001}` };
     _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval;
     return _kubeApiConfig.kubeConfig;
+  } else if (typeof options.kubeConfigPath === 'string' && fs.existsSync(options.kubeConfigPath)) {
+    kc.loadFromFile(options.kubeConfigPath);
   } else {
     // First tries to load from process.env.KUBECONFIG, then from $HOME/.kube/config, then finally loadFromCluster
     kc.loadFromDefault();
@@ -72,11 +64,11 @@ module.exports = function kubeApiConfig(options = {}) {
     result.key = base64Decode(user.keyData || user['client-key-data']);
   }
   if (user.authProvider) {
-    let tokenFilePath = objectPath.get(user, ['authProvider', 'config', 'tokenFile']);
+    let tokenFilePath = user?.authProvider?.config?.tokenFile;
     if (tokenFilePath) {
       result.headers = { 'Authorization': `Bearer ${fs.readFileSync(tokenFilePath, { encoding: 'utf8' })}` };
     } else {
-      let idToken = objectPath.get(user, ['authProvider', 'config', 'id-token']);
+      let idToken = user?.authProvider?.config?.['id-token'];
       result.headers = { 'Authorization': `Bearer ${idToken}` };
     }
   } else if (user.token) {
@@ -87,7 +79,8 @@ module.exports = function kubeApiConfig(options = {}) {
   const userAgentName = process.env.USER_AGENT_NAME || 'razee-io/kubernetes-util';
   const userAgentVersion = process.env.USER_AGENT_VERSION || packagejson.version;
 
-  objectPath.set(result, 'headers.User-Agent', `${userAgentName}/${userAgentVersion}`);
+  result.headers = { ...result.headers, 'User-Agent': `${userAgentName}/${userAgentVersion}` };
+
   _kubeApiConfig.kubeConfig = result;
   _kubeApiConfig.refreshTimestamp = Date.now() + refreshInterval; // refresh in refreshInterval or 5 minutes if not defined
   return result;

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -13,22 +13,23 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+const KubeApiConfig = require('./KubeApiConfig');
+
 const objectPath = require('object-path');
 const request = require('request-promise-native');
 const merge = require('deepmerge');
 
 module.exports = class KubeResourceMeta {
-  constructor(path, rm, kubeApiConfig) {
+  constructor(path, rm) {
     this._path = path;
     this._resourceMeta = rm;
-    this._kubeApiConfig = kubeApiConfig;
     this._extraHeaders = {};
 
     this._logger = require('./bunyan-api').createLogger('KubeResourceMeta');
   }
 
   clone() {
-    return new KubeResourceMeta(this._path, this._resourceMeta, this._kubeApiConfig);
+    return new KubeResourceMeta(this._path, this._resourceMeta);
   }
 
   uri(options = {}) {
@@ -72,7 +73,7 @@ module.exports = class KubeResourceMeta {
     return Array.isArray(this._resourceMeta.verbs) ? this._resourceMeta.verbs : [];
   }
   get kubeApiConfig() {
-    return this._kubeApiConfig;
+    return KubeApiConfig;
   }
   get extraHeaders() {
     return this._extraHeaders;

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -94,25 +94,25 @@ module.exports = class KubeResourceMeta {
 
   async request(reqOpt) {
     this._logger.debug(`Request ${reqOpt.method || 'GET'} ${reqOpt.uri || reqOpt.url}`);
-    return request(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt]));
+    return request(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async get(name, ns, reqOpt = {}) {
     const uri = this.uri({ name: name, namespace: ns });
     this._logger.debug(`Get ${uri}`);
-    return request.get(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt, { uri: uri, json: true }]));
+    return request.get(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
   }
 
   async put(file, reqOpt = {}) {
     const uri = this.uri({ name: objectPath.get(file, 'metadata.name'), namespace: objectPath.get(file, 'metadata.namespace') });
     this._logger.debug(`Put ${uri}`);
-    return request.put(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt, { uri: uri, json: file }]));
+    return request.put(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
   }
 
   async post(file, reqOpt = {}) {
     const uri = this.uri({ namespace: objectPath.get(file, 'metadata.namespace') });
     this._logger.debug(`Post ${uri}`);
-    return request.post(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt, { uri: uri, json: file }]));
+    return request.post(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
   }
 
   async patch(name, ns, jPatch, reqOpt = {}) {
@@ -120,7 +120,7 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`Json Patch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: jPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/json-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async jsonPatch(name, ns, jPatch, reqOpt = {}) {
@@ -132,7 +132,7 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`MergePatch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: mPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/merge-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async strategicMergePatch(name, ns, smPatch, reqOpt = {}) {
@@ -140,13 +140,13 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`StrategicMergePatch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: smPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/strategic-merge-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async delete(name, ns, reqOpt = {}) {
     const uri = this.uri({ name: name, namespace: ns });
     this._logger.debug(`Delete ${uri}`);
-    return request.delete(merge.all([this._kubeApiConfig, this._extraHeaders, reqOpt, { uri: uri, json: true }]));
+    return request.delete(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
   }
 
 };

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -13,11 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-const KubeApiConfig = require('./KubeApiConfig');
-
 const objectPath = require('object-path');
 const request = require('request-promise-native');
 const merge = require('deepmerge');
+
+const KubeApiConfig = require('./KubeApiConfig');
 
 module.exports = class KubeResourceMeta {
   constructor(path, rm) {

--- a/lib/KubeResourceMeta.js
+++ b/lib/KubeResourceMeta.js
@@ -95,25 +95,25 @@ module.exports = class KubeResourceMeta {
 
   async request(reqOpt) {
     this._logger.debug(`Request ${reqOpt.method || 'GET'} ${reqOpt.uri || reqOpt.url}`);
-    return request(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
+    return request(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async get(name, ns, reqOpt = {}) {
     const uri = this.uri({ name: name, namespace: ns });
     this._logger.debug(`Get ${uri}`);
-    return request.get(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
+    return request.get(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
   }
 
   async put(file, reqOpt = {}) {
     const uri = this.uri({ name: objectPath.get(file, 'metadata.name'), namespace: objectPath.get(file, 'metadata.namespace') });
     this._logger.debug(`Put ${uri}`);
-    return request.put(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
+    return request.put(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
   }
 
   async post(file, reqOpt = {}) {
     const uri = this.uri({ namespace: objectPath.get(file, 'metadata.namespace') });
     this._logger.debug(`Post ${uri}`);
-    return request.post(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
+    return request.post(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: file }]));
   }
 
   async patch(name, ns, jPatch, reqOpt = {}) {
@@ -121,7 +121,7 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`Json Patch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: jPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/json-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async jsonPatch(name, ns, jPatch, reqOpt = {}) {
@@ -133,7 +133,7 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`MergePatch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: mPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/merge-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async strategicMergePatch(name, ns, smPatch, reqOpt = {}) {
@@ -141,13 +141,13 @@ module.exports = class KubeResourceMeta {
     this._logger.debug(`StrategicMergePatch ${uri}`);
     reqOpt = merge(reqOpt, { uri: uri, json: smPatch });
     objectPath.set(reqOpt, ['headers', 'content-type'], objectPath.get(reqOpt, ['headers', 'content-type']) || 'application/strategic-merge-patch+json');
-    return request.patch(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt]));
+    return request.patch(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt]));
   }
 
   async delete(name, ns, reqOpt = {}) {
     const uri = this.uri({ name: name, namespace: ns });
     this._logger.debug(`Delete ${uri}`);
-    return request.delete(merge.all([this._kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
+    return request.delete(merge.all([this.kubeApiConfig(), this._extraHeaders, reqOpt, { uri: uri, json: true }]));
   }
 
 };

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -27,14 +27,20 @@ module.exports = class Watchman {
       throw 'Watchman objectHandler must be a function.';
     }
     this._objectHandler = objectHandler;
-    this._requestOptions = merge({
-      headers: {
-        'User-Agent': 'razee-watchman'
-      },
-      json: true, // Automatically parses the JSON string in the response
-      resolveWithFullResponse: true,
-      simple: false
-    }, options.requestOptions ?? {});
+    this._requestOptions = merge.all(
+      [
+        KubeApiConfig(),
+        {
+          headers: {
+            'User-Agent': 'razee-watchman'
+          },
+          json: true, // Automatically parses the JSON string in the response
+          resolveWithFullResponse: true,
+          simple: false
+        },
+        options.requestOptions ?? {}
+      ]
+    );
 
     if ((options.logger) && ((typeof options.logger) !== 'object')) {
       throw 'options.logger must be an object.';

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -19,6 +19,8 @@ const JSONStream = require('JSONStream');
 const delay = require('delay');
 const merge = require('deepmerge');
 
+const KubeApiConfig = require('./KubeApiConfig');
+
 module.exports = class Watchman {
   constructor(options, objectHandler) {
     if ((typeof objectHandler) !== 'function') {
@@ -32,8 +34,7 @@ module.exports = class Watchman {
       json: true, // Automatically parses the JSON string in the response
       resolveWithFullResponse: true,
       simple: false
-    }, options.requestOptions || {});
-    this._requestOptions.uri = options.watchUri;
+    }, options.requestOptions ?? {});
 
     if ((options.logger) && ((typeof options.logger) !== 'object')) {
       throw 'options.logger must be an object.';
@@ -82,7 +83,7 @@ module.exports = class Watchman {
     this._logger.debug('Watchman: initializing watch');
     this.end(this._rewatchOnTimeout);
     this._logger.debug('Watchman: attempting new watch ');
-    this._requestStream = request(this._requestOptions)
+    this._requestStream = request(merge(KubeApiConfig(), this._requestOptions))
       .on('response', (response) => {
         if (response.statusCode !== 200) {
           if (this._logger) {

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -34,7 +34,7 @@ module.exports = class Watchman {
           headers: {
             'User-Agent': 'razee-watchman'
           },
-          baseUrl: kac.baseUrl,
+          baseUrl: kac.baseUrl, // needs the baseurl for validUrl check, but i dont want the other KubeApiConfig values here so that we can fetch them before each call to watch().
           json: true, // Automatically parses the JSON string in the response
           resolveWithFullResponse: true,
           simple: false

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -46,7 +46,7 @@ module.exports = class Watchman {
       throw 'options.logger must be an object.';
     }
     this._logger = options.logger;
-    if (!validUrl.isUri(`${this._requestOptions.baseUrl}${this._requestOptions.uri}`) || !this._requestOptions.uri.includes('watch')) {
+    if (!validUrl.isUri(`${this._requestOptions.baseUrl}${this._requestOptions.uri}`) || !this._requestOptions?.uri?.includes('watch')) {
       throw `uri '${this._requestOptions.baseUrl}${this._requestOptions.uri}' not valid watch uri.`;
     }
 

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -88,6 +88,7 @@ module.exports = class Watchman {
     this._logger.debug('Watchman: initializing watch');
     this.end(this._rewatchOnTimeout);
     this._logger.debug('Watchman: attempting new watch ');
+    // this._requestOptions must not contain a prior KubeApiConfig(), otherwise the old values will overrite the newly fetched ones
     this._requestStream = request(merge(KubeApiConfig(), this._requestOptions))
       .on('response', (response) => {
         if (response.statusCode !== 200) {

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -27,12 +27,14 @@ module.exports = class Watchman {
       throw 'Watchman objectHandler must be a function.';
     }
     this._objectHandler = objectHandler;
+    const kac = KubeApiConfig();
     this._requestOptions = merge.all(
       [
         {
           headers: {
             'User-Agent': 'razee-watchman'
           },
+          baseUrl: kac.baseUrl,
           json: true, // Automatically parses the JSON string in the response
           resolveWithFullResponse: true,
           simple: false

--- a/lib/Watchman.js
+++ b/lib/Watchman.js
@@ -29,7 +29,6 @@ module.exports = class Watchman {
     this._objectHandler = objectHandler;
     this._requestOptions = merge.all(
       [
-        KubeApiConfig(),
         {
           headers: {
             'User-Agent': 'razee-watchman'

--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -48,7 +48,7 @@ module.exports = class KubeClass {
     }
     let apiResourceList = coreApiList.body;
     let resourceMetaList = apiResourceList.resources;
-    let result = resourceMetaList.map(r => new KubeResourceMeta(`/api/${apiResourceList.groupVersion}`, r, KubeApiConfig));
+    let result = resourceMetaList.map(r => new KubeResourceMeta(`/api/${apiResourceList.groupVersion}`, r));
     return result;
   }
 
@@ -114,7 +114,7 @@ module.exports = class KubeClass {
     if (response.statusCode == 200 && objectPath.get(response, 'body.kind') === 'APIResourceList') {
       let resources = objectPath.get(response, 'body.resources');
       resources.map((r) => {
-        let krm = new KubeResourceMeta(`/apis/${groupVersion}`, r, KubeApiConfig);
+        let krm = new KubeResourceMeta(`/apis/${groupVersion}`, r);
         krmHandler(krm);
       });
       return { statusCode: response.statusCode, groupVersion: groupVersion };

--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -19,12 +19,13 @@ const clone = require('clone');
 const objectPath = require('object-path');
 
 const KubeResourceMeta = require('./KubeResourceMeta');
+const KubeApiConfig = require('./KubeApiConfig');
+
 const kubeResourceMetaCache = {};
 
 module.exports = class KubeClass {
 
   constructor(kubeApiConfig, logger) {
-    this._kubeApiConfig = kubeApiConfig;
     this._log = logger || require('./bunyan-api').createLogger('kubeClass');
     this._baseOptions = merge({
       headers: {
@@ -33,7 +34,7 @@ module.exports = class KubeClass {
       json: true,
       simple: false,
       resolveWithFullResponse: true
-    }, this._kubeApiConfig);
+    }, KubeApiConfig());
   }
 
   async getCoreApis() {
@@ -43,7 +44,7 @@ module.exports = class KubeClass {
     }
     let apiResourceList = coreApiList.body;
     let resourceMetaList = apiResourceList.resources;
-    let result = resourceMetaList.map(r => new KubeResourceMeta(`/api/${apiResourceList.groupVersion}`, r, this._kubeApiConfig));
+    let result = resourceMetaList.map(r => new KubeResourceMeta(`/api/${apiResourceList.groupVersion}`, r, KubeApiConfig));
     return result;
   }
 
@@ -109,7 +110,7 @@ module.exports = class KubeClass {
     if (response.statusCode == 200 && objectPath.get(response, 'body.kind') === 'APIResourceList') {
       let resources = objectPath.get(response, 'body.resources');
       resources.map((r) => {
-        let krm = new KubeResourceMeta(`/apis/${groupVersion}`, r, this._kubeApiConfig);
+        let krm = new KubeResourceMeta(`/apis/${groupVersion}`, r, KubeApiConfig);
         krmHandler(krm);
       });
       return { statusCode: response.statusCode, groupVersion: groupVersion };

--- a/lib/kubeClass.js
+++ b/lib/kubeClass.js
@@ -25,9 +25,13 @@ const kubeResourceMetaCache = {};
 
 module.exports = class KubeClass {
 
-  constructor(kubeApiConfig, logger) {
+  constructor(logger) {
     this._log = logger || require('./bunyan-api').createLogger('kubeClass');
-    this._baseOptions = merge({
+  }
+
+  get _baseOptions() {
+    // need to re-compute base options every call in case KubeApiConfig needs to get a fresh token
+    return merge({
       headers: {
         Accept: 'application/json'
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,6 +447,41 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@panva/asn1.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
@@ -776,6 +811,15 @@
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -802,9 +846,9 @@
       }
     },
     "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "node_modules/asynckit": {
@@ -1094,61 +1138,14 @@
       }
     },
     "node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/clone": {
@@ -1165,15 +1162,6 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dependencies": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -1212,6 +1200,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/consola": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -1451,6 +1445,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -2007,6 +2022,34 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2017,6 +2060,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -2441,6 +2493,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/got": {
       "version": "11.8.2",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
@@ -2506,27 +2578,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -2677,12 +2728,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/interpret": {
@@ -2691,15 +2742,6 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-arguments": {
@@ -3423,27 +3465,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/leprechaun": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/leprechaun/-/leprechaun-0.0.2.tgz",
-      "integrity": "sha1-i5ZRSp5jTFP75ZqAlPM3jI+yCE0=",
-      "dev": true,
-      "dependencies": {
-        "log-symbols": "^1.0.2"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3513,79 +3534,6 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
-    "node_modules/lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
-      "dev": true
-    },
-    "node_modules/log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -3642,6 +3590,28 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -3689,9 +3659,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "node_modules/minipass": {
@@ -3818,17 +3788,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/mocha/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3926,39 +3885,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/mocha/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
       "optional": true,
       "engines": {
         "node": "*"
@@ -4009,15 +3939,15 @@
       "dev": true
     },
     "node_modules/nconf": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+      "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
       "dev": true,
       "dependencies": {
-        "async": "^1.4.0",
-        "ini": "^1.3.0",
+        "async": "^3.0.0",
+        "ini": "^2.0.0",
         "secure-keys": "^1.0.0",
-        "yargs": "^3.19.0"
+        "yargs": "^16.1.1"
       },
       "engines": {
         "node": ">= 0.4.0"
@@ -4160,15 +4090,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/nyc": {
@@ -4516,18 +4437,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
@@ -4847,6 +4756,26 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -5112,6 +5041,16 @@
         "lowercase-keys": "^2.0.0"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfc4648": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
@@ -5143,6 +5082,29 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5375,6 +5337,15 @@
       "dependencies": {
         "has-flag": "^4.0.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6023,18 +5994,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "dev": true,
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6051,64 +6010,54 @@
       "dev": true
     },
     "node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "number-is-nan": "^1.0.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -6159,35 +6108,54 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml-lint": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/yaml-lint/-/yaml-lint-1.2.4.tgz",
-      "integrity": "sha512-qpKE0szyKsE9TrlVPi+bxKxVAjl30QjNAOyOxy7noQdf/WCCYUlT4xiCRxMG48eyeBzMBtBN6PgGfaB0MJePNw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yaml-lint/-/yaml-lint-1.6.0.tgz",
+      "integrity": "sha512-vHOD02BBTuX5IR7+AsDYp0AukGjstZ/tPkBwtC3A1l/TDbCDU/BCJHUNLy0y8AWdPfi28pdkWAStgli91lvXVA==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.1.2",
-        "js-yaml": "^3.10.0",
-        "leprechaun": "0.0.2",
-        "lodash.merge": "^4.6.1",
-        "lodash.snakecase": "^4.1.1",
-        "nconf": "^0.10.0"
+        "consola": "^2.15.3",
+        "globby": "^11.1.0",
+        "js-yaml": "^4.1.0",
+        "nconf": "^0.12.0"
       },
       "bin": {
-        "yamllint": "cli.js"
+        "yamllint": "dist/cli.js"
+      }
+    },
+    "node_modules/yaml-lint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/yaml-lint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
@@ -6228,68 +6196,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -6677,6 +6583,32 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@panva/asn1.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
@@ -6966,6 +6898,12 @@
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -6986,9 +6924,9 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "asynckit": {
@@ -7219,51 +7157,14 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "clone": {
@@ -7278,12 +7179,6 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -7318,6 +7213,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "consola": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -7502,6 +7403,23 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -7927,6 +7845,30 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -7937,6 +7879,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -8258,6 +8209,20 @@
         }
       }
     },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
     "got": {
       "version": "11.8.2",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
@@ -8308,23 +8273,6 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
       }
     },
     "has-flag": {
@@ -8438,21 +8386,15 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
     },
     "is-arguments": {
       "version": "1.1.0",
@@ -9014,24 +8956,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
-    "leprechaun": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/leprechaun/-/leprechaun-0.0.2.tgz",
-      "integrity": "sha1-i5ZRSp5jTFP75ZqAlPM3jI+yCE0=",
-      "dev": true,
-      "requires": {
-        "log-symbols": "^1.0.2"
-      }
-    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -9092,63 +9016,6 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
-      "dev": true
-    },
-    "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -9195,6 +9062,22 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -9227,9 +9110,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "minipass": {
@@ -9326,17 +9209,6 @@
             }
           }
         },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9406,39 +9278,13 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
         }
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
       "optional": true
     },
     "ms": {
@@ -9477,15 +9323,15 @@
       "dev": true
     },
     "nconf": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+      "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "ini": "^1.3.0",
+        "async": "^3.0.0",
+        "ini": "^2.0.0",
         "secure-keys": "^1.0.0",
-        "yargs": "^3.19.0"
+        "yargs": "^16.1.1"
       }
     },
     "ncp": {
@@ -9596,12 +9442,6 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         }
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "nyc": {
       "version": "15.1.0",
@@ -9877,15 +9717,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "^1.0.0"
-      }
-    },
     "p-cancelable": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
@@ -10127,6 +9958,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -10337,6 +10174,12 @@
         "lowercase-keys": "^2.0.0"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rfc4648": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
@@ -10364,6 +10207,15 @@
             "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -10560,6 +10412,12 @@
           }
         }
       }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "source-map": {
       "version": "0.5.7",
@@ -11085,12 +10943,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "dev": true
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -11104,49 +10956,39 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
         }
       }
     },
@@ -11185,81 +11027,47 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml-lint": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/yaml-lint/-/yaml-lint-1.2.4.tgz",
-      "integrity": "sha512-qpKE0szyKsE9TrlVPi+bxKxVAjl30QjNAOyOxy7noQdf/WCCYUlT4xiCRxMG48eyeBzMBtBN6PgGfaB0MJePNw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yaml-lint/-/yaml-lint-1.6.0.tgz",
+      "integrity": "sha512-vHOD02BBTuX5IR7+AsDYp0AukGjstZ/tPkBwtC3A1l/TDbCDU/BCJHUNLy0y8AWdPfi28pdkWAStgli91lvXVA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2",
-        "js-yaml": "^3.10.0",
-        "leprechaun": "0.0.2",
-        "lodash.merge": "^4.6.1",
-        "lodash.snakecase": "^4.1.1",
-        "nconf": "^0.10.0"
+        "consola": "^2.15.3",
+        "globby": "^11.1.0",
+        "js-yaml": "^4.1.0",
+        "nconf": "^0.12.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-          "dev": true
-        }
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       }
     },
     "yargs-parser": {

--- a/test/Watchman-test.js
+++ b/test/Watchman-test.js
@@ -17,6 +17,7 @@ const assert = require('chai').assert;
 const nock = require('nock');
 const watchman = require('../lib/Watchman');
 const log = require('../lib/bunyan-api').createLogger('Watchman-test');
+const KubeApiConfig = require('../lib/KubeApiConfig');
 
 const dummyOptions = { rewatchOnTimeout: false, requestOptions: { baseUrl: 'https://localhost:32263', uri: '/api/v1/watch/namespaces/default/services/kubernetes' } };
 const data1 = { 'type': 'ADDED', 'object': { 'kind': 'Service', 'apiVersion': 'v1', 'metadata': { 'name': 'kubernetes', 'namespace': 'default', 'selfLink': '/api/v1/namespaces/default/services/kubernetes', 'uid': '7c75c135-fca7-11e8-9f10-3a7d3a0f8cf2', 'resourceVersion': '14840391', 'creationTimestamp': '2018-12-10T18:14:51Z', 'labels': { 'component': 'apiserver', 'provider': 'kubernetes', 'razee/watch-resource': 'lite' } }, 'spec': { 'ports': [{ 'name': 'https', 'protocol': 'TCP', 'port': 443, 'targetPort': 2040 }], 'clusterIP': '172.21.0.1', 'type': 'ClusterIP', 'sessionAffinity': 'None' }, 'status': { 'loadBalancer': {} } } };
@@ -49,11 +50,12 @@ describe('watchman', () => {
       }
     });
     it('bad uri', () => {
+      KubeApiConfig({ localhost: true });
       let errorsHappen = false;
       try {
         var wm = new watchman('', mockObjectHandler); // eslint-disable-line no-unused-vars
       } catch (err) {
-        assert.equal(err, 'uri \'undefinedundefined\' not valid watch uri.');
+        assert.equal(err, 'uri \'http://localhost:8001undefined\' not valid watch uri.');
         errorsHappen = true;
       }
       assert.isTrue(errorsHappen);

--- a/test/Watchman-test.js
+++ b/test/Watchman-test.js
@@ -18,6 +18,7 @@ const nock = require('nock');
 const watchman = require('../lib/Watchman');
 const log = require('../lib/bunyan-api').createLogger('Watchman-test');
 const KubeApiConfig = require('../lib/KubeApiConfig');
+KubeApiConfig({ localhost: true });
 
 const dummyOptions = { rewatchOnTimeout: false, requestOptions: { baseUrl: 'https://localhost:32263', uri: '/api/v1/watch/namespaces/default/services/kubernetes' } };
 const data1 = { 'type': 'ADDED', 'object': { 'kind': 'Service', 'apiVersion': 'v1', 'metadata': { 'name': 'kubernetes', 'namespace': 'default', 'selfLink': '/api/v1/namespaces/default/services/kubernetes', 'uid': '7c75c135-fca7-11e8-9f10-3a7d3a0f8cf2', 'resourceVersion': '14840391', 'creationTimestamp': '2018-12-10T18:14:51Z', 'labels': { 'component': 'apiserver', 'provider': 'kubernetes', 'razee/watch-resource': 'lite' } }, 'spec': { 'ports': [{ 'name': 'https', 'protocol': 'TCP', 'port': 443, 'targetPort': 2040 }], 'clusterIP': '172.21.0.1', 'type': 'ClusterIP', 'sessionAffinity': 'None' }, 'status': { 'loadBalancer': {} } } };
@@ -50,7 +51,6 @@ describe('watchman', () => {
       }
     });
     it('bad uri', () => {
-      KubeApiConfig({ localhost: true });
       let errorsHappen = false;
       try {
         var wm = new watchman('', mockObjectHandler); // eslint-disable-line no-unused-vars

--- a/test/Watchman-test.js
+++ b/test/Watchman-test.js
@@ -18,10 +18,10 @@ const nock = require('nock');
 const watchman = require('../lib/Watchman');
 const log = require('../lib/bunyan-api').createLogger('Watchman-test');
 
-const dummyOptions = { rewatchOnTimeout: false, requestOptions: { baseUrl: 'https://localhost:32263' }, watchUri: '/api/v1/watch/namespaces/default/services/kubernetes' };
+const dummyOptions = { rewatchOnTimeout: false, requestOptions: { baseUrl: 'https://localhost:32263', uri: '/api/v1/watch/namespaces/default/services/kubernetes' } };
 const data1 = { 'type': 'ADDED', 'object': { 'kind': 'Service', 'apiVersion': 'v1', 'metadata': { 'name': 'kubernetes', 'namespace': 'default', 'selfLink': '/api/v1/namespaces/default/services/kubernetes', 'uid': '7c75c135-fca7-11e8-9f10-3a7d3a0f8cf2', 'resourceVersion': '14840391', 'creationTimestamp': '2018-12-10T18:14:51Z', 'labels': { 'component': 'apiserver', 'provider': 'kubernetes', 'razee/watch-resource': 'lite' } }, 'spec': { 'ports': [{ 'name': 'https', 'protocol': 'TCP', 'port': 443, 'targetPort': 2040 }], 'clusterIP': '172.21.0.1', 'type': 'ClusterIP', 'sessionAffinity': 'None' }, 'status': { 'loadBalancer': {} } } };
 
-let mockObjectHandler = (data) => {}; // eslint-disable-line no-unused-vars
+let mockObjectHandler = (data) => { }; // eslint-disable-line no-unused-vars
 
 describe('watchman', () => {
 

--- a/test/kubeClass-test.js
+++ b/test/kubeClass-test.js
@@ -16,7 +16,8 @@
 const assert = require('chai').assert;
 const nock = require('nock');
 const deepEqual = require('deep-equal');
-const { KubeClass } = require('../index');
+const { KubeClass, KubeApiConfig } = require('../index');
+KubeApiConfig({ localhost: true });
 // const objectPath = require('object-path');
 
 describe('kubeClass', function () {
@@ -25,7 +26,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -34,7 +35,7 @@ describe('kubeClass', function () {
     });
 
     it('#success', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithFile(200, __dirname + '/replies/coreApis.json', { 'Content-Type': 'application/json' });
       let ca = await kc.getCoreApis();
@@ -44,7 +45,7 @@ describe('kubeClass', function () {
     });
 
     it('#error', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithError('bad things happened man');
       try {
@@ -62,7 +63,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -71,7 +72,7 @@ describe('kubeClass', function () {
     });
 
     it('#success latest no duplicates', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .replyWithFile(200, __dirname + '/replies/apiGroups.json', { 'Content-Type': 'application/json' })
         .get('/apis/apps/v1')
@@ -93,7 +94,7 @@ describe('kubeClass', function () {
     });
 
     it('#success all with duplicates', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .replyWithFile(200, __dirname + '/replies/apiGroups.json', { 'Content-Type': 'application/json' })
         .get('/apis/apps/v1')
@@ -115,7 +116,7 @@ describe('kubeClass', function () {
     });
 
     it('#success no ApiList', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .reply(200, {
           'kind': 'APIGroupList',
@@ -140,7 +141,7 @@ describe('kubeClass', function () {
     });
 
     it('#404', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .replyWithFile(200, __dirname + '/replies/apiGroups.json', { 'Content-Type': 'application/json' })
         .get('/apis/apps/v1')
@@ -166,7 +167,7 @@ describe('kubeClass', function () {
     });
 
     it('#error', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .replyWithError('bad things happened man');
       try {
@@ -183,7 +184,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -191,8 +192,8 @@ describe('kubeClass', function () {
       nock.cleanAll();
     });
 
-    it('#success', async () => {
-      nock('http://localhost/')
+    it.only('#success', async () => {
+      nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithFile(200, __dirname + '/replies/coreApis.json', { 'Content-Type': 'application/json' })
         .get('/apis')
@@ -211,11 +212,12 @@ describe('kubeClass', function () {
         .replyWithFile(200, __dirname + '/replies/batch-v2alpha1.json', { 'Content-Type': 'application/json' });
 
       let mr = await kc.getKubeResourcesMeta('watch');
+      console.log(mr);
       assert.equal(mr.length, 8, 'Should get 8 MetaResources that support watch');
     });
 
     it('#success w/out verb', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithFile(200, __dirname + '/replies/coreApis.json', { 'Content-Type': 'application/json' })
         .get('/apis')
@@ -239,10 +241,10 @@ describe('kubeClass', function () {
     });
 
     it('#error', async () => {
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithError('bad things happened man');
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get('/apis')
         .replyWithError('other bad things happened man');
       try {
@@ -260,7 +262,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -284,7 +286,7 @@ describe('kubeClass', function () {
         'resource-metadata': krm,
         object: exampleResource
       };
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .query((actualQueryObject) => {
           return deepEqual(actualQueryObject, queryObject);
@@ -309,7 +311,7 @@ describe('kubeClass', function () {
         'resource-metadata': krm,
         error: resourceNotFound
       };
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .reply(404, resourceNotFound);
       let r = await kc.getResource(krm);
@@ -330,7 +332,7 @@ describe('kubeClass', function () {
         kind: 'Deployment',
         'verbs': ['watch']
       });
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .replyWithError('bad things happened man');
       try {
@@ -347,7 +349,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -370,7 +372,7 @@ describe('kubeClass', function () {
         'resource-metadata': krm,
         object: exampleResource
       }];
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .query((actualQueryObject) => {
           return deepEqual(actualQueryObject, queryObject);
@@ -386,7 +388,7 @@ describe('kubeClass', function () {
     var kc;
 
     beforeEach(() => {
-      kc = new KubeClass({ baseUrl: 'http://localhost' });
+      kc = new KubeClass();
     });
 
     afterEach(() => {
@@ -410,7 +412,7 @@ describe('kubeClass', function () {
         'resource-metadata': krm,
         object: exampleResource
       }];
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .query((actualQueryObject) => {
           return deepEqual(actualQueryObject, queryObject);
@@ -442,7 +444,7 @@ describe('kubeClass', function () {
         'resource-metadata': krm,
         object: exampleResource
       }];
-      nock('http://localhost/')
+      nock('http://localhost:8001')
         .get(krm.uri())
         .query((actualQueryObject) => {
           return deepEqual(actualQueryObject, queryObject);

--- a/test/kubeClass-test.js
+++ b/test/kubeClass-test.js
@@ -192,7 +192,7 @@ describe('kubeClass', function () {
       nock.cleanAll();
     });
 
-    it.only('#success', async () => {
+    it('#success', async () => {
       nock('http://localhost:8001')
         .get('/api/v1')
         .replyWithFile(200, __dirname + '/replies/coreApis.json', { 'Content-Type': 'application/json' })
@@ -212,7 +212,6 @@ describe('kubeClass', function () {
         .replyWithFile(200, __dirname + '/replies/batch-v2alpha1.json', { 'Content-Type': 'application/json' });
 
       let mr = await kc.getKubeResourcesMeta('watch');
-      console.log(mr);
       assert.equal(mr.length, 8, 'Should get 8 MetaResources that support watch');
     });
 


### PR DESCRIPTION
starting in Kube 1.22, service account tokens are mounted as projected volumes on pods, and those tokens are rotated on a regular interval. For the time being the old tokens are marked as stale, but still valid. At some point in the future, the old tokens will no longer be valid. This PR should update our controllers to re-fetch the token at a regular interval to ensure we always use a valid token when talking to the kube api.

refs:
- https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#token-controller
- https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
    - Service account token secrets can still be [created manually](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token) if you need a token that never 
expires
- https://github.com/kubernetes-client/javascript/blob/b92ddb7296261388abcbce7e67fac70a50e8b06a/src/config.ts#L293-L349